### PR TITLE
Add /guildinvite chat command for guild leaders

### DIFF
--- a/ErenshorQoL/ErenshorQoLMod.cs
+++ b/ErenshorQoL/ErenshorQoLMod.cs
@@ -124,6 +124,7 @@ namespace ErenshorQoL
         internal static ConfigEntry<Toggle> AutoPetOnAggro = null!;
         internal static ConfigEntry<Toggle> AutoPetOnAutoAttackToggle = null!;
         internal static ConfigEntry<Toggle> AutoPriceItem = null!;
+        internal static ConfigEntry<Toggle> GuildInviteCommandToggle = null!;
         internal static ConfigEntry<int> ConfigCleanup = null!;
 
         internal static bool _configApplied;
@@ -173,6 +174,10 @@ namespace ErenshorQoL
                 UpdateSocialLog.LogAdd("/forge - Opens the forge (blacksmithing) window", "lightblue");
                 UpdateSocialLog.LogAdd("/auction - Opens the auction hall window", "lightblue");
                 UpdateSocialLog.LogAdd("/allscenes - Lists all scenes", "lightblue");
+                if (ErenshorQoLMod.GuildInviteCommandToggle.Value == Toggle.On)
+                {
+                    UpdateSocialLog.LogAdd("/guildinvite SimName - Invite a SimPlayer to your guild by name (alias: /ginvite)", "lightblue");
+                }
             }
             static void HelpPlayer()
             {
@@ -330,6 +335,52 @@ namespace ErenshorQoL
                     UpdateSocialLog.LogAdd("Remove item from cursor before interacting with the forge.", "yellow");
                 }
             }
+            public static void DoGuildInvite(string targetName)
+            {
+                if (ErenshorQoLMod.GuildInviteCommandToggle.Value == Toggle.Off)
+                {
+                    return;
+                }
+                if (string.IsNullOrEmpty(targetName))
+                {
+                    UpdateSocialLog.LogAdd("Usage: /guildinvite SimPlayerName", "yellow");
+                    return;
+                }
+                if (string.IsNullOrEmpty(GameData.PlayerControl.MyGuild))
+                {
+                    UpdateSocialLog.LogAdd("You're not currently in a guild.", "yellow");
+                    return;
+                }
+                LiveGuildData guildData = GameData.GuildManager.GetGuildDataByID(GameData.PlayerControl.MyGuild);
+                if (guildData == null)
+                {
+                    UpdateSocialLog.LogAdd("Could not find your guild data.", "yellow");
+                    return;
+                }
+                if (!guildData.PlayerIsGuildLeader)
+                {
+                    UpdateSocialLog.LogAdd("You must be a guild leader to invite players.", "yellow");
+                    return;
+                }
+                // Find SimPlayer by name (case-insensitive)
+                SimPlayerTracking? foundSim = null;
+                foreach (SimPlayerTracking sim in GameData.SimMngr.Sims)
+                {
+                    if (sim.SimName.Equals(targetName, System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        foundSim = sim;
+                        break;
+                    }
+                }
+                if (foundSim == null)
+                {
+                    UpdateSocialLog.LogAdd("Could not find a player named '" + targetName + "'.", "yellow");
+                    return;
+                }
+                UpdateSocialLog.LogAdd("Guild invite sent to " + foundSim.SimName + "...", "yellow");
+                GameData.PlayerAud.PlayOneShot(GameData.Misc.Click, GameData.SFXVol);
+                GameData.GuildManager.SendSimPlayerGuildInvite(foundSim, guildData);
+            }
             public static void DoAllScenes()
             {
                 if (ErenshorQoLMod.QoLCommandsToggle.Value == Toggle.Off)
@@ -370,6 +421,12 @@ namespace ErenshorQoL
                             return false;
                         case "allscenes":
                             QoLCommands.DoAllScenes();
+                            return false;
+                        case "guildinvite":
+                        case "ginvite":
+                            // Get raw name from input (preserve original case for display)
+                            string rawName = spl.Length > 1 ? txt.Substring(txt.IndexOf(' ') + 1).Trim() : string.Empty;
+                            QoLCommands.DoGuildInvite(rawName);
                             return false;
                         case "help":
                             if (arg == "player")

--- a/ErenshorQoL/Utilities.cs
+++ b/ErenshorQoL/Utilities.cs
@@ -26,6 +26,7 @@ namespace ErenshorQoL
             ErenshorQoLMod.QoLAuctionKey = ErenshorQoLMod.context.config("2 - QoL Commands", "Auction Key", new KeyboardShortcut(KeyCode.F10), new ConfigDescription("Key(s) used to open the Auction House window. Use https://docs.unity3d.com/Manual/ConventionalGameInput.html", new ErenshorQoLMod.AcceptableShortcuts()));
             ErenshorQoLMod.QoLForgeKey = ErenshorQoLMod.context.config("2 - QoL Commands", "Forge Key", new KeyboardShortcut(KeyCode.F10, KeyCode.LeftShift), new ConfigDescription("Key(s) used to open the Forge window. Use https://docs.unity3d.com/Manual/ConventionalGameInput.html", new ErenshorQoLMod.AcceptableShortcuts()));
             ErenshorQoLMod.AutoPriceItem = ErenshorQoLMod.context.config("6 - Auto Price Item", "Auto Set AH Item Price", ErenshorQoLMod.Toggle.On, "Automatically start with the highest sellable auction house price when adding an item.");
+            ErenshorQoLMod.GuildInviteCommandToggle = ErenshorQoLMod.context.config("2 - QoL Commands", "Enable Guild Invite Command", ErenshorQoLMod.Toggle.On, "Enable /guildinvite and /ginvite commands to invite SimPlayers to your guild by name.");
             ErenshorQoLMod.ConfigCleanup = ErenshorQoLMod.context.config("Utility", "ConfigCleanup", 0, "Tracks cleanup of obsolete config settings and can be ignored.");
 
             // Cleanup


### PR DESCRIPTION
## Summary
- Adds `/guildinvite <SimPlayerName>` (alias `/ginvite`) chat command that lets guild leaders invite SimPlayers by name without needing to target them first
- Uses the existing `GuildManager.SendSimPlayerGuildInvite()` flow so SimPlayer personality/opinion checks still apply
- Case-insensitive name matching, configurable toggle, error messages for common cases (no guild, not leader, player not found)

## Test plan
- [x] Build succeeds (tested on WSL Debian with dotnet build)
- [x] `/guildinvite <name>` invites SimPlayer when player is guild leader
- [x] `/ginvite` alias works
- [x] Error when not in a guild
- [x] Error when not guild leader
- [x] Error when no name provided (shows usage)
- [x] Error when name not found
- [x] `/help mods` shows the new command
- [x] Config toggle disables the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)